### PR TITLE
Remove stage 0 from setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ It must be an array of the transforms you want to use:
 
 ```js
 {
-  "stage": 0,
   "env": {
     "production": { //only applies when NODE_ENV is set to 'production'
       "plugins": [


### PR DESCRIPTION
There's no reason this needs to be in the example config and makes it incompatible with Babel 6
