### PR TITLE
Update README for Babel 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,20 @@ It must be an array of the transforms you want to use:
   "env": {
     "production": { //only applies when NODE_ENV is set to 'production'
       "plugins": [
-        "react-transform"
-      ],
-      "extra": {
-        "react-transform": {
-          "transforms": [{
-            "transform" : "react-transform-sentry",
-            "imports" : ["react"]
-          }]
-        }
-      }
+        [
+          "react-transform",
+          {
+            "transforms": [
+              {
+                "transform": "react-transform-sentry",
+                "imports": [
+                  "react"
+                ]
+              }
+            ]
+          }
+        ]
+      ]
     }
   }
 }


### PR DESCRIPTION
Hi! 

I was playing around with this plugin and had to work around an issue with the setup instructions when using Babel 6.

The `extra` property is deprecated and the build will error; I've gotten plugin working with the new configuration style, and figured I'd share it.
